### PR TITLE
Cli for add server accepts ipv4 and ipv6 address

### DIFF
--- a/cmd/action.go
+++ b/cmd/action.go
@@ -41,8 +41,15 @@ var CliAction = func(ctx *cli.Context) error {
 		//Create variable of type IpAddress and set IP address
 		// to it
 		var IpAddr p2p.IpAddress
-		IpAddr.Ipv4 = AddServer
 
+		//Checking if the address is a ipv4
+		// or ipv6 address
+		ip4Orip6 := p2p.Ip4or6(AddServer)
+		if ip4Orip6 == "version 6" {
+			IpAddr.Ipv6 = AddServer
+		} else {
+			IpAddr.Ipv4 = AddServer
+		}
 		// Append IP address to variable result which
 		// is a list
 		res.IpAddress = append(res.IpAddress, IpAddr)

--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -108,7 +108,6 @@ var AppConfigFlags = []cli.Flag{
 		EnvVars: []string{"SPECS"},
 		Destination: &Specs,
 	},
-
 	&cli.BoolFlag{
 		Name:        "SetDefaultConfig",
 		Aliases: []string{"dc"},

--- a/p2p/ip_table.json
+++ b/p2p/ip_table.json
@@ -1,11 +1,3 @@
 {
- "ip_address": [
-  {
-   "ipv4": "",
-   "ipv6": "2001:8f8:172d:ee93:7588:ad57:c351:3309",
-   "latency": 1213198,
-   "download": 0,
-   "upload": 0
-  }
- ]
+ "ip_address": null
 }

--- a/p2p/ip_table.json
+++ b/p2p/ip_table.json
@@ -1,3 +1,11 @@
 {
- "ip_address": null
+ "ip_address": [
+  {
+   "ipv4": "",
+   "ipv6": "2001:8f8:172d:ee93:8105:563b:dc98:6dbf",
+   "latency": 567539,
+   "download": 0,
+   "upload": 0
+  }
+ ]
 }


### PR DESCRIPTION
Code snippet modified 
```
var IpAddr p2p.IpAddress

		//Checking if the address is a ipv4
		// or ipv6 address
		ip4Orip6 := p2p.Ip4or6(AddServer)
		if ip4Orip6 == "version 6" {
			IpAddr.Ipv6 = AddServer
		} else {
			IpAddr.Ipv4 = AddServer
		}
```