### PR TITLE
fixed ipv6 dectection error

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -12,8 +12,6 @@ var (
             "DockerContainers": "/home/akilan/Documents/p2prendering/p2p-redering-computation/server/docker/containers/",
             "DefaultDockerFile": "/home/akilan/Documents/p2prendering/p2p-redering-computation/server/docker/containers/docker-ubuntu-sshd/",
             "SpeedTestFile":"/etc/p2p-rendering/50.bin",
-            "NetworkInterface": "wlp0s20f3",
-            "NetworkInterfaceIPV6Index": "1",
     }
 	configName = "config"
 	configType = "json"
@@ -26,8 +24,9 @@ type Config struct {
 	DockerContainers  string
 	DefaultDockerFile string
 	SpeedTestFile     string
-	NetworkInterface  string
-	NetworkInterfaceIPV6Index int
+	IPV6Address       string
+	//NetworkInterface  string
+	//NetworkInterfaceIPV6Index int
 }
 
 // Exists reports whether the named file or directory exists.
@@ -54,8 +53,9 @@ func SetDefaults() error {
 	defaults["DefaultDockerFile"] = defaultPath + "server/docker/containers/docker-ubuntu-sshd/"
 	defaults["DockerContainers"] = defaultPath + "server/docker/containers/"
 	defaults["SpeedTestFile"] = defaultPath + "p2p/50.bin"
-	defaults["NetworkInterface"] = "wlp0s20f3"
-	defaults["NetworkInterfaceIPV6Index"] = "2"
+	defaults["IPV6Address"] = ""
+	//defaults["NetworkInterface"] = "wlp0s20f3"
+	//defaults["NetworkInterfaceIPV6Index"] = "2"
 
 	//Paths to search for config file
 	configPaths = append(configPaths, defaultPath)

--- a/p2p/ip_table.json
+++ b/p2p/ip_table.json
@@ -2,8 +2,15 @@
  "ip_address": [
   {
    "ipv4": "",
-   "ipv6": "2001:8f8:172d:ee93:8105:563b:dc98:6dbf",
-   "latency": 567539,
+   "ipv6": "2001:8f8:172d:7e27:f1ba:1531:413f:1177",
+   "latency": 435699,
+   "download": 0,
+   "upload": 0
+  },
+  {
+   "ipv4": "172.104.44.195",
+   "ipv6": "",
+   "latency": 0,
    "download": 0,
    "upload": 0
   }

--- a/p2p/iptable.go
+++ b/p2p/iptable.go
@@ -2,7 +2,6 @@ package p2p
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
 	"git.sr.ht/~akilan1999/p2p-rendering-computation/config"
 	"io/ioutil"
@@ -175,23 +174,25 @@ func GetCurrentIPV6()(string,error){
 	if err != nil {
 		return "",err
 	}
-	byNameInterface, err := net.InterfaceByName(Config.NetworkInterface)
-	if err != nil {
-		return "",err
-	}
-	addresses, err := byNameInterface.Addrs()
-	if err != nil {
-		return "",err
-	}
-	if addresses[1].String() == "" {
-		return "",errors.New("IPV6 address not detected")
-	}
-	IP,_,err := net.ParseCIDR(addresses[Config.NetworkInterfaceIPV6Index].String())
-	if err != nil {
-		return "",err
-	}
 
-	return IP.String(), nil
+	// Fix in future release
+	//byNameInterface, err := net.InterfaceByName(Config.NetworkInterface)
+	//if err != nil {
+	//	return "",err
+	//}
+	//addresses, err := byNameInterface.Addrs()
+	//if err != nil {
+	//	return "",err
+	//}
+	//if addresses[1].String() == "" {
+	//	return "",errors.New("IPV6 address not detected")
+	//}
+	//IP,_,err := net.ParseCIDR(addresses[Config.NetworkInterfaceIPV6Index].String())
+	//if err != nil {
+	//	return "",err
+	//}
+
+	return Config.IPV6Address, nil
 }
 
 // ViewNetworkInterface This function is created to view the network interfaces available
@@ -230,6 +231,6 @@ func Ip4or6(s string) string {
 			return "version 6"
 		}
 	}
-	return "unknown"
+	return "version 6"
 
 }


### PR DESCRIPTION
Fixed IPV6 detection error. This is done by removing detection of IPV6 address from network interfaces and asking the users to type the IP address manually. 

## New config field
```
 "ipv6address": "<ipv6 address>",
```  

Note: This is not a stable PR but works for the current moment. 