### PR TITLE
added fix in if statement to fix simple error when adding ipv6 address

### DIFF
--- a/cmd/action.go
+++ b/cmd/action.go
@@ -53,7 +53,6 @@ var CliAction = func(ctx *cli.Context) error {
 		// Append IP address to variable result which
 		// is a list
 		res.IpAddress = append(res.IpAddress, IpAddr)
-		
 		// Adds the new server IP to the iptable
 		res.WriteIpTable()
 

--- a/p2p/iptable.go
+++ b/p2p/iptable.go
@@ -131,12 +131,11 @@ func (table *IpAddresses)RemoveDuplicates() error {
 	for i, _:= range table.IpAddress {
 		Exists := false
 		for k := range NoDuplicates.IpAddress {
-			if NoDuplicates.IpAddress[k].Ipv4 == table.IpAddress[i].Ipv4 || (NoDuplicates.IpAddress[k].Ipv6 != "" && NoDuplicates.IpAddress[k].Ipv6 == table.IpAddress[i].Ipv6){
+			if (NoDuplicates.IpAddress[k].Ipv4 != "" && NoDuplicates.IpAddress[k].Ipv4 == table.IpAddress[i].Ipv4) || (NoDuplicates.IpAddress[k].Ipv6 != "" && NoDuplicates.IpAddress[k].Ipv6 == table.IpAddress[i].Ipv6) {
 				Exists = true
 				break
 			}
 		}
-
 		if Exists {
 			continue
 		}

--- a/p2p/iptable_test.go
+++ b/p2p/iptable_test.go
@@ -65,3 +65,13 @@ func TestViewNetworkInterface(t *testing.T) {
 		t.Error()
 	}
 }
+
+func TestIp4or6(t *testing.T) {
+	// This test ensures that the ipv6 address gets detected
+	test := "2001:8f8:172d:7e27:4f23:ae4:bce5:e037"
+	res := Ip4or6(test)
+	if res != "version 6" {
+		t.Fail()
+	}
+
+}

--- a/server/docker/docker_test.go
+++ b/server/docker/docker_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 )
 
-func TestDocker(t *testing.T) {
+func TestDockerUbuntuSSHDProvided(t *testing.T) {
 	// Testing by providing default container name
 	_,err := BuildRunContainer(2,"false","docker-ubuntu-sshd")
 
@@ -12,13 +12,15 @@ func TestDocker(t *testing.T) {
 		t.Error(err)
 	}
 
-	// Testing if no container name is provided if default is used
-	_,err = BuildRunContainer(2,"false","")
+}
+
+func TestDockerDefaultContainer(t *testing.T) {
+	// Testing by providing without providing default container name
+	_,err := BuildRunContainer(2,"false","")
 
 	if err != nil {
 		t.Error(err)
 	}
-
 }
 
 func TestContainerHorovod(t *testing.T) {


### PR DESCRIPTION
possible for ```--as``` flag to add ipv6 address.

### fix 
```
if (NoDuplicates.IpAddress[k].Ipv4 != "" && NoDuplicates.IpAddress[k].Ipv4 == table.IpAddress[i].Ipv4) || (NoDuplicates.IpAddress[k].Ipv6 != "" && NoDuplicates.IpAddress[k].Ipv6 == table.IpAddress[i].Ipv6)
```