### PR TITLE
Added possibility to run server on any port

### DIFF
--- a/client/Iptable.go
+++ b/client/Iptable.go
@@ -13,7 +13,7 @@ import (
 )
 
 // UpdateIpTable Does the following to update it's IP table
-func UpdateIpTable(IpAddress string) error {
+func UpdateIpTable(IpAddress string, serverPort string) error {
 
 	config, err := config.ConfigInit()
 	if err != nil {
@@ -22,16 +22,17 @@ func UpdateIpTable(IpAddress string) error {
 
 	client := http.Client{}
 
+
 	var resp []byte
 
 	version := p2p.Ip4or6(IpAddress)
 	if version == "version 6" {
-	  resp, err = UploadMultipartFile(client,"http://["+IpAddress+"]:8088/IpTable","json",config.IPTable)
+	  resp, err = UploadMultipartFile(client,"http://[" + IpAddress + "]:" + serverPort + "/IpTable","json",config.IPTable)
 	  if err != nil {
 		return err
 	  }
 	} else {
-		resp, err = UploadMultipartFile(client,"http://"+IpAddress+":8088/IpTable","json",config.IPTable)
+		resp, err = UploadMultipartFile(client,"http://" + IpAddress + ":" + serverPort + "/IpTable","json",config.IPTable)
 		if err != nil {
 			return err
 		}
@@ -114,9 +115,9 @@ func UpdateIpTableListClient() error {
 			//}
 
 			if Addresses.IpAddress[j].Ipv6 != "" {
-				err = UpdateIpTable(Addresses.IpAddress[j].Ipv6)
+				err = UpdateIpTable(Addresses.IpAddress[j].Ipv6, Addresses.IpAddress[j].ServerPort)
 			} else {
-				err = UpdateIpTable(Addresses.IpAddress[j].Ipv4)
+				err = UpdateIpTable(Addresses.IpAddress[j].Ipv4, Addresses.IpAddress[j].ServerPort)
 			}
 
 			if err != nil {

--- a/client/ServerSpecs.go
+++ b/client/ServerSpecs.go
@@ -15,6 +15,13 @@ import (
 func GetSpecs(IP string)(*server.SysInfo,error) {
 	var URL string
 	version := p2p.Ip4or6(IP)
+
+	//Get port number of the server
+	serverPort, err := GetServerPort(IP)
+	if err != nil {
+		return nil, err
+	}
+
 	if version == "version 6" {
 		URL = "http://[" + IP + "]:" + serverPort + "/server_info"
 	} else {

--- a/client/trackcontainers/trackcontainers.json
+++ b/client/trackcontainers/trackcontainers.json
@@ -1,3 +1,0 @@
-{
-	"TrackContainer": []
-}

--- a/cmd/action.go
+++ b/cmd/action.go
@@ -23,13 +23,24 @@ var CliAction = func(ctx *cli.Context) error {
 		if err != nil {
 			fmt.Print(err)
 		}
-
-		p2p.PrintIpTable()
+		// Reads from ip table and passes it
+		// on to struct print function
+		Servers, err := p2p.ReadIpTable()
+		if err != nil {
+			return err
+		}
+		client.PrettyPrint(Servers)
 	}
 
 	// Displays the IP table
 	if ServerList {
-		p2p.PrintIpTable()
+		// Reads from ip table and passes it
+		// on to struct print function
+		Servers, err := p2p.ReadIpTable()
+		if err != nil {
+			return err
+		}
+		client.PrettyPrint(Servers)
 	}
 
 	// Add provided IP to the IP table
@@ -50,6 +61,13 @@ var CliAction = func(ctx *cli.Context) error {
 			IpAddr.Ipv6 = AddServer
 		} else {
 			IpAddr.Ipv4 = AddServer
+		}
+
+		// If a server port is provided then set it
+		if Ports != "" {
+			IpAddr.ServerPort = Ports
+		} else {
+			IpAddr.ServerPort = "8088"
 		}
 		// Append IP address to variable result which
 		// is a list

--- a/config/config.go
+++ b/config/config.go
@@ -28,6 +28,7 @@ type Config struct {
 	IPV6Address         string
 	PluginPath          string
 	TrackContainersPath string
+	ServerPort          string
 	//NetworkInterface  string
 	//NetworkInterfaceIPV6Index int
 }
@@ -96,6 +97,7 @@ func SetDefaults() error {
 	defaults["IPV6Address"] = ""
 	defaults["PluginPath"] = defaultPath + "plugin/deploy"
 	defaults["TrackContainersPath"] = defaultPath + "client/trackcontainers/trackcontainers.json"
+	defaults["ServerPort"] = "8088"
 	//defaults["NetworkInterface"] = "wlp0s20f3"
 	//defaults["NetworkInterfaceIPV6Index"] = "2"
 

--- a/p2p/ip_table.json
+++ b/p2p/ip_table.json
@@ -1,11 +1,12 @@
 {
  "ip_address": [
   {
-   "ipv4": "172.104.44.195",
+   "ipv4": "139.162.246.221",
    "ipv6": "",
    "latency": 0,
    "download": 0,
-   "upload": 0
+   "upload": 0,
+   "serverport": "8088"
   }
  ]
 }

--- a/p2p/iptable.go
+++ b/p2p/iptable.go
@@ -23,6 +23,7 @@ type IpAddress struct {
 	Latency  time.Duration `json:"latency"`
 	Download float64    `json:"download"`
 	Upload float64 `json:"upload"`
+	ServerPort string `json:"serverport"`
 }
 
 type IP struct {
@@ -69,6 +70,7 @@ func ReadIpTable()(*IpAddresses ,error){
 	}
 	PublicIP.Ipv4 = ip
 	PublicIP.Ipv6 = ipv6
+	PublicIP.ServerPort = config.ServerPort
 
 	// Updates current machine IP address to the IP table
 	ipAddresses.IpAddress = append(ipAddresses.IpAddress, PublicIP)
@@ -120,6 +122,7 @@ func PrintIpTable() error {
 			"-----------------\n",table.IpAddress[i].Ipv4,table.IpAddress[i].Ipv6,
 			table.IpAddress[i].Latency)
 	}
+
 	return nil
 }
 

--- a/p2p/testingMetrics.go
+++ b/p2p/testingMetrics.go
@@ -105,7 +105,7 @@ func (s *IpAddress)UploadSpeed() error {
 
 	b, w := createMultipartFormData("file",config.SpeedTestFile)
 
-	req, err := http.NewRequest("GET", "http://" + s.Ipv4 + ":8088/upload", &b)
+	req, err := http.NewRequest("GET", "http://" + s.Ipv4 + ":" + s.ServerPort + "/upload", &b)
 	if err != nil {
 		return err
 	}
@@ -152,10 +152,10 @@ func (s *IpAddress) PingTest() error {
 	//pingURL := strings.Split(s.URL, "/upload")[0] + "/latency.txt"
 	var pingURL string
 	if s.Ipv6 != "" {
-		pingURL = "http://[" + s.Ipv6 + "]:8088/server_info"
+		pingURL = "http://[" + s.Ipv6 + "]:" + s.ServerPort + "/server_info"
 		s.Ipv4 = ""
 	} else {
-		pingURL = "http://" + s.Ipv4 + ":8088/server_info"
+		pingURL = "http://" + s.Ipv4 + ":" + s.ServerPort + "/server_info"
 	}
 
 	l := time.Duration(100000000000) // 10sec

--- a/server/server.go
+++ b/server/server.go
@@ -122,7 +122,7 @@ func Server() error{
 		c.String(http.StatusOK, "success")
 	})
 
-	//Show images avaliable
+	//Show images available
 	r.GET("/ShowImages", func(c *gin.Context) {
 		resp, err := docker.ViewAllContainers()
 		if err != nil {
@@ -131,8 +131,14 @@ func Server() error{
 		c.JSON(http.StatusOK, resp)
 	})
 
-	//Port running on
-	err := r.Run(":8088")
+	//Get Server port based on the config file
+	config, err := config.ConfigInit()
+	if err != nil {
+		return err
+	}
+
+	// Run gin server on the specified port
+	err = r.Run(":" + config.ServerPort)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## Problem 
In the previous implementation the server was required on run on port 8088.

## Solution 
The server can run on any port and still be a part of the network. This is done 
by adding a new field in the iptable file. 

```
 {
   "ipv4": "<ip address>",
   "ipv6": "",
   "latency": 0,
   "download": 0,
   "upload": 0,
   // New field 
   "serverport": "<new field>"
  }
```