### PR TITLE
changed back to default print when using IP tables

### DIFF
--- a/cmd/action.go
+++ b/cmd/action.go
@@ -25,22 +25,23 @@ var CliAction = func(ctx *cli.Context) error {
 		}
 		// Reads from ip table and passes it
 		// on to struct print function
-		Servers, err := p2p.ReadIpTable()
-		if err != nil {
-			return err
-		}
-		client.PrettyPrint(Servers)
+		//Servers, err := p2p.ReadIpTable()
+		//if err != nil {
+		//	return err
+		//}
+		//client.PrettyPrint(Servers)
+		p2p.PrintIpTable()
 	}
 
 	// Displays the IP table
 	if ServerList {
 		// Reads from ip table and passes it
 		// on to struct print function
-		Servers, err := p2p.ReadIpTable()
-		if err != nil {
-			return err
-		}
-		client.PrettyPrint(Servers)
+		//Servers, err := p2p.ReadIpTable()
+		//if err != nil {
+		//	return err
+		//}
+		p2p.PrintIpTable()
 	}
 
 	// Add provided IP to the IP table

--- a/p2p/iptable.go
+++ b/p2p/iptable.go
@@ -118,9 +118,9 @@ func PrintIpTable() error {
 	}
 
 	for i := 0; i < len(table.IpAddress); i++ {
-		fmt.Printf("\nIP Address: %s\nIPV6: %s\nLatency: %s\n-----------" +
+		fmt.Printf("\nIP Address: %s\nIPV6: %s\nLatency: %s\nServerPort: %s\n-----------" +
 			"-----------------\n",table.IpAddress[i].Ipv4,table.IpAddress[i].Ipv6,
-			table.IpAddress[i].Latency)
+			table.IpAddress[i].Latency, table.IpAddress[i].ServerPort)
 	}
 
 	return nil


### PR DESCRIPTION
## Switch print from 
```
{
	"ip_address": [
		{
			"ipv4": "",
			"ipv6": "",
			"latency": 127668460,
			"download": 0,
			"upload": 0,
			"serverport": "8088"
		},
		{
			"ipv4": "",
			"ipv6": "",
			"latency": 483662,
			"download": 0,
			"upload": 0,
			"serverport": "8088"
		}
	]
} 
```
## to 
```
IP Address:
IPV6: 
Latency: 137.052961ms
ServerPort: 8088
----------------------------

IP Address: 
IPV6: 
Latency: 596.398µs
ServerPort: 8088
----------------------------

```