### PR TITLE
Execute groups when running plugins 

### DIFF
--- a/Docs/Installation.md
+++ b/Docs/Installation.md
@@ -144,7 +144,7 @@ p2prc --tc
 
 ### Running plugin 
 ```
-p2prc --plugin <plugin name> --id <container id>
+p2prc --plugin <plugin name> --id <container id or group id>
 ``` 
 
 ### Create group
@@ -165,7 +165,7 @@ p2prc --group <group id>
 ```
 ### Delete container from group
 ```
-p2prc --rmcgroup --group <group id> --id <contianer id> 
+p2prc --rmcgroup --group <group id> --id <container id> 
 ```
 ### Delete entire group
 ```

--- a/client/TrackContainers.go
+++ b/client/TrackContainers.go
@@ -163,3 +163,14 @@ func GetContainerInformation(ID string) (*TrackContainer, error) {
 	}
 	return nil, errors.New("Container not found. ")
 }
+
+// CheckID Checks if the ID belongs to a group or a single container
+func CheckID(ID string) (string,error) {
+    // For group checks if the 1st characters is "grp"
+	if ID[0:3] == "grp" {
+		return "group", nil
+	} else {
+		return "container", nil
+	}
+	return "",nil
+}

--- a/client/TrackContianers_test.go
+++ b/client/TrackContianers_test.go
@@ -102,3 +102,19 @@ func TestRemoveTrackedContainer(t *testing.T) {
 		t.Fail()
 	}
 }
+
+// Test function that checks if the ID belongs to
+// a group or container running
+func TestCheckID(t *testing.T) {
+    id := "grp123"
+	checkID, err := CheckID(id)
+	if err != nil {
+		fmt.Println(err)
+		t.Fail()
+	}
+	if checkID == "group" {
+		fmt.Println("pass")
+	} else {
+		t.Fail()
+	}
+}

--- a/cmd/action.go
+++ b/cmd/action.go
@@ -167,9 +167,9 @@ var CliAction = func(ctx *cli.Context) error {
 	//Executing plugin when the plugin flag is called
 	// --plugin
 	if ExecutePlugin != "" {
-		// The execute plugin requires the container ID provided when being executed
+		// To execute plugin requires the container ID or group ID provided when being executed
 		if ID != "" {
-			err := plugin.RunPluginCli(ExecutePlugin, ID)
+			err := plugin.CheckRunPlugin(ExecutePlugin, ID)
 			if err != nil {
 				fmt.Println(err)
 			} else {


### PR DESCRIPTION
## Changes
The cli command to run plugins can now accept either container id or group id. Using group id would make easy to execute the same instructions in a set of containers in a single command. 

```
p2prc --plugin <plugin name> --id <container id or group id>
```
