### PR TITLE
cli upgrade

### DIFF
--- a/Bindings/Haskell/cabal.project
+++ b/Bindings/Haskell/cabal.project
@@ -1,4 +1,4 @@
 
 packages: ./p2prc.cabal
 
-index-state: 2024-11-09T17:56:52Z
+index-state: 2025-06-15T21:24:15Z

--- a/Bindings/Haskell/flake.lock
+++ b/Bindings/Haskell/flake.lock
@@ -96,15 +96,14 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 0,
-        "narHash": "sha256-5qbaxawuLsg8iu9076zlAbLtTFSNJaTz7WERS5rWRxU=",
-        "path": "/nix/store/lg694r23fzc6v5ai3qqcszq1fp44djg2-source",
+        "path": "../../",
         "type": "path"
       },
       "original": {
-        "path": "/nix/store/lg694r23fzc6v5ai3qqcszq1fp44djg2-source",
+        "path": "../../",
         "type": "path"
-      }
+      },
+      "parent": []
     },
     "root": {
       "inputs": {

--- a/Bindings/Haskell/lib/API.hs
+++ b/Bindings/Haskell/lib/API.hs
@@ -32,6 +32,7 @@ import CLI
   , eitherExecProcessParser
   , spawnProcP2PRC
   )
+import System.Console.GetOpt (usageInfo)
 
 -- import System.Environment (lookupEnv)
 
@@ -43,12 +44,32 @@ data P2PRCapi
   = MkP2PRCapi
     { startServer       :: IOEitherError ProcessHandle
       -- ^ Start server
-    -- , execInitConfig    :: IOEitherError P2PRCConfig
+    , execInitConfig    :: IOEitherError P2PRCConfig
       -- ^ Instantiate server configuration
     , execListServers   :: IOEitherError IPAddressTable
       -- ^ List servers in network
     , execMapPort       :: MapPortRequest -> IOEitherError MapPortResponse
       -- ^ Exposes and associates a local TCP port with a remote DNS address
+
+
+    -- -p port
+    -- --arn
+    -- --ip value
+    -- --as value
+    -- --us
+    -- --amd
+
+    -- # Set root port
+    -- p2prc --arn --ip 0.0.0.0 -p "$rootPort"
+    --
+    -- # add current node
+    -- p2prc --as 0.0.0.0 -p "$NEW_PORT"
+    --
+    -- --us
+    -- --amd
+    --
+    --
+    --
     }
 
 
@@ -115,9 +136,7 @@ p2prcAPI =
           ]
           MkEmptyStdInput
 
-    -- , execInitConfig = do
-
-    --   confInitRes <- execProcP2PRC [ MkOptAtomic "--dc" ] MkEmptyStdInput
+    , execInitConfig = execProcP2PRCParser [ MkOptAtomic "--dc" ] MkEmptyStdInput
 
     --   case confInitRes of
     --     (Right _) -> do

--- a/Bindings/Haskell/lib/Engine.hs
+++ b/Bindings/Haskell/lib/Engine.hs
@@ -95,7 +95,7 @@ runP2PRC
 
   ( MkP2PRCapi
     { startServer     = startServer
-    -- , execInitConfig  = execInitConfig
+    , execInitConfig  = execInitConfig
     , execListServers = execListServers
     , execMapPort     = execMapPort
     }
@@ -105,7 +105,7 @@ runP2PRC
       let
 
 
-      -- configValue <- execInitConfig
+      configValue <- execInitConfig
 
       -- TODO: get name of host server from config json
 


### PR DESCRIPTION
I opened this PR to have early feedback from you

- I have just added a new version of cabal version of packages. it is quite old now


I am adding a few more cli options:
- -port <port>
- --arn
- --ip <value>
- --as <value>
- --us
- --amd <value>

My first question is: do these commands change the underlying json, so each p2prc instance updates its state from reading the json?


Request: can we have a special flag to define special config values (I will inject json value into this flag value)? at least (ServerPort, Test and BehindNAT) would be a good start